### PR TITLE
instarepo automatic PR

### DIFF
--- a/CodeFmt.lpr
+++ b/CodeFmt.lpr
@@ -14,9 +14,9 @@ uses
 
 {$R *.res}
 
-  function RightSeekPos(const substr, s: string): integer;
+  function RightSeekPos(const substr, s: String): Integer;
   var
-    i, k: integer;
+    i, k: Integer;
   begin
     k := Length(substr);
     i := Length(s) - k + 1;
@@ -25,9 +25,9 @@ uses
     Result := i;
   end;
 
-  function GetFormatterType(s: string): TFormatterType;
+  function GetFormatterType(s: String): TFormatterType;
   var
-    toUpper: string;
+    toUpper: String;
   begin
     toUpper := UpperCase(s);
     if toUpper = 'RTF' then
@@ -39,13 +39,13 @@ uses
   end;
 
 const
-  sExt: array [ftHtml..ftRtf] of string = ('.html', '.rtf');
+  sExt: array [ftHtml..ftRtf] of String = ('.html', '.rtf');
 var
-  sFileName: string;
-  sName: string;
-  sFormatted: string;
+  sFileName: String;
+  sName: String;
+  sFormatted: String;
   formatterType: TFormatterType;
-  i: integer;
+  i: Integer;
   InputStream, OutputStream: TFileStream;
 begin
   if (ParamCount = 2) or (ParamCount = 3) then

--- a/CppLexer.pas
+++ b/CppLexer.pas
@@ -22,7 +22,7 @@ implementation
 uses TokenTypes;
 
 const
-  CppKeyWords: array [0..59] of string =
+  CppKeyWords: array [0..59] of String =
     ('_cs', '_ds', '_es', '_export', '_fastcall',
     '_loadds', '_saveregs', '_seg', '_ss', 'asm',
     'auto', 'break', 'case', 'cdecl', 'char',
@@ -60,9 +60,9 @@ begin
   end;
 end;
 
-function ArrayContains(hay: array of string; needle: string): boolean;
+function ArrayContains(hay: array of String; needle: String): Boolean;
 var
-  i: integer;
+  i: Integer;
 begin
   Result := False;
 
@@ -76,7 +76,7 @@ end;
 
 procedure TCppLexer.HandleIdentifier;
 var
-  token: string;
+  token: String;
   tokenType: TTokenType;
 begin
   if StreamTokenizer.Scan(['a'..'z', 'A'..'Z'], ['a'..'z', 'A'..'Z', '_']) then

--- a/FormatterBase.pas
+++ b/FormatterBase.pas
@@ -19,21 +19,21 @@ type
     property OutputStream: TStream read FOutputStream;
 
     { Writes the given string to the output }
-    procedure Write(const str: string);
+    procedure Write(const str: String);
 
     { Writes the given string to the output, followed by a newline }
-    procedure WriteLn(const str: string);
+    procedure WriteLn(const str: String);
   public
     constructor Create(OutputStream: TStream);
     procedure WriteHeader; virtual; abstract;
     procedure WriteFooter; virtual; abstract;
-    procedure WriteToken(const Token: string; const TokenType: TTokenType);
+    procedure WriteToken(const Token: String; const TokenType: TTokenType);
       virtual; abstract;
   end;
 
 implementation
 
-procedure TFormatterBase.Write(const str: string);
+procedure TFormatterBase.Write(const str: String);
 var
   b, Buf: PChar;
 begin
@@ -47,7 +47,7 @@ begin
   end;
 end;
 
-procedure TFormatterBase.WriteLn(const str: string);
+procedure TFormatterBase.WriteLn(const str: String);
 begin
   Write(str);
   Write(LineEnding);

--- a/HTMLFormatter.pas
+++ b/HTMLFormatter.pas
@@ -10,18 +10,18 @@ uses
 type
   THTMLFormatter = class(TFormatterBase)
   private
-    function SetSpecial(const str: string): string;
+    function SetSpecial(const str: String): String;
   public
     procedure WriteFooter; override;
     procedure WriteHeader; override;
-    procedure WriteToken(const Token: string; const TokenType: TTokenType); override;
+    procedure WriteToken(const Token: String; const TokenType: TTokenType); override;
   end;
 
 implementation
 
-procedure THTMLFormatter.WriteToken(const Token: string; const TokenType: TTokenType);
+procedure THTMLFormatter.WriteToken(const Token: String; const TokenType: TTokenType);
 var
-  escapedToken, FormatToken: string;
+  escapedToken, FormatToken: String;
 begin
   escapedToken := SetSpecial(Token);
   case TokenType of
@@ -42,9 +42,9 @@ begin
   Write(FormatToken);
 end;
 
-function THTMLFormatter.SetSpecial(const str: string): string;
+function THTMLFormatter.SetSpecial(const str: String): String;
 var
-  i: integer;
+  i: Integer;
 begin
   Result := '';
   for i := 1 to Length(str) do

--- a/LexerBase.pas
+++ b/LexerBase.pas
@@ -9,7 +9,7 @@ uses
 
 type
   { A callback method that is called when a token is found. }
-  TLexerTokenFound = procedure(const Token: string;
+  TLexerTokenFound = procedure(const Token: String;
     const TokenType: TTokenType) of object;
 
   { Base class for a lexer }
@@ -48,7 +48,7 @@ procedure HandleSlashesComment(StreamTokenizer: TStreamTokenizer;
 { Handles a single line comment. The comment denoting characters are
 identified by the CommentMark parameter. }
 procedure HandleLineComment(StreamTokenizer: TStreamTokenizer;
-  TokenFound: TLexerTokenFound; CommentMark: string);
+  TokenFound: TLexerTokenFound; CommentMark: String);
 
 implementation
 
@@ -59,7 +59,7 @@ end;
 
 procedure TLexerBase.FormatStream(InputStream: TStream);
 var
-  oldPosition: integer;
+  oldPosition: Integer;
 begin
   FStreamTokenizer := TStreamTokenizer.Create(InputStream);
   try
@@ -123,7 +123,7 @@ begin
 end;
 
 procedure HandleLineComment(StreamTokenizer: TStreamTokenizer;
-  TokenFound: TLexerTokenFound; CommentMark: string);
+  TokenFound: TLexerTokenFound; CommentMark: String);
 begin
   if StreamTokenizer.PeekLength(Length(CommentMark)) = CommentMark then
   begin

--- a/PascalLexer.pas
+++ b/PascalLexer.pas
@@ -18,9 +18,9 @@ type
     procedure HandleMultilineComment;
     procedure HandleChar;
     procedure HandleHexNumber;
-    function IsDiffKey(aToken: string): boolean;
-    function IsDirective(aToken: string): boolean;
-    function IsKeyword(aToken: string): boolean;
+    function IsDiffKey(aToken: String): Boolean;
+    function IsDirective(aToken: String): Boolean;
+    function IsKeyword(aToken: String): Boolean;
   protected
     procedure Scan; override;
   end;
@@ -30,7 +30,7 @@ implementation
 uses TokenTypes;
 
 const
-  PasKeywords: array[0..98] of string =
+  PasKeywords: array[0..98] of String =
     ('ABSOLUTE', 'ABSTRACT', 'AND', 'ARRAY', 'AS', 'ASM', 'ASSEMBLER',
     'AUTOMATED', 'BEGIN', 'CASE', 'CDECL', 'CLASS', 'CONST', 'CONSTRUCTOR',
     'DEFAULT', 'DESTRUCTOR', 'DISPID', 'DISPINTERFACE', 'DIV', 'DO',
@@ -47,11 +47,11 @@ const
     'UNIT', 'UNTIL', 'USES', 'VAR', 'VIRTUAL', 'WHILE', 'WITH', 'WRITE',
     'WRITEONLY', 'XOR');
 
-  PasDirectives: array[0..10] of string =
+  PasDirectives: array[0..10] of String =
     ('AUTOMATED', 'INDEX', 'NAME', 'NODEFAULT', 'READ', 'READONLY',
     'RESIDENT', 'STORED', 'STRINGRECOURCE', 'WRITE', 'WRITEONLY');
 
-  PasDiffKeys: array[0..6] of string =
+  PasDiffKeys: array[0..6] of String =
     ('END', 'FUNCTION', 'PRIVATE', 'PROCEDURE', 'PRODECTED',
     'PUBLIC', 'PUBLISHED');
 
@@ -75,7 +75,7 @@ end;
 *)
 procedure TPascalLexer.HandleAnsiComments;
 
-  function IsEndOfAnsiComment: boolean;
+  function IsEndOfAnsiComment: Boolean;
   begin
     IsEndOfAnsiComment := (StreamTokenizer.Current = '*') and
       (StreamTokenizer.PeekNext = ')');
@@ -165,10 +165,10 @@ begin
     CurrentTokenFound(ttNumber);
 end;
 
-function BinarySearch(hay: array of string; needle: string): boolean;
+function BinarySearch(hay: array of String; needle: String): Boolean;
 var
-  First, Last, I, Compare: integer;
-  Token: string;
+  First, Last, I, Compare: Integer;
+  Token: String;
 begin
   First := Low(hay);
   Last := High(hay);
@@ -191,16 +191,16 @@ begin
   end;
 end;
 
-function TPascalLexer.IsDiffKey(aToken: string): boolean;
+function TPascalLexer.IsDiffKey(aToken: String): Boolean;
 begin
   Result := BinarySearch(PasDiffKeys, aToken);
 end;  { IsDiffKey }
 
-function TPascalLexer.IsDirective(aToken: string): boolean;
+function TPascalLexer.IsDirective(aToken: String): Boolean;
 var
-  First, Last, I, Compare: integer;
-  Token: string;
-  FDiffer: boolean;
+  First, Last, I, Compare: Integer;
+  Token: String;
+  FDiffer: Boolean;
 begin
   First := Low(PasDirectives);
   Last := High(PasDirectives);
@@ -237,14 +237,14 @@ begin
   end;
 end;
 
-function TPascalLexer.IsKeyword(aToken: string): boolean;
+function TPascalLexer.IsKeyword(aToken: String): Boolean;
 begin
   Result := BinarySearch(PasKeywords, aToken);
 end;
 
 procedure TPascalLexer.HandleIdentifier;
 var
-  token: string;
+  token: String;
   tokenType: TTokenType;
 begin
   (* cannot start with number but it can contain one *)

--- a/RTFFormatter.pas
+++ b/RTFFormatter.pas
@@ -10,18 +10,18 @@ uses
 type
   TRTFFormatter = class(TFormatterBase)
   private
-    function SetSpecial(const str: string): string;
+    function SetSpecial(const str: String): String;
   public
     procedure WriteFooter; override;
     procedure WriteHeader; override;
-    procedure WriteToken(const Token: string; const TokenType: TTokenType); override;
+    procedure WriteToken(const Token: String; const TokenType: TTokenType); override;
   end;
 
 implementation
 
-procedure TRTFFormatter.WriteToken(const Token: string; const TokenType: TTokenType);
+procedure TRTFFormatter.WriteToken(const Token: String; const TokenType: TTokenType);
 var
-  escapedToken, FormatToken: string;
+  escapedToken, FormatToken: String;
 begin
   escapedToken := SetSpecial(Token);
   case TokenType of
@@ -38,9 +38,9 @@ begin
   Write(FormatToken);
 end;
 
-function TRTFFormatter.SetSpecial(const str: string): string;
+function TRTFFormatter.SetSpecial(const str: String): String;
 var
-  i: integer;
+  i: Integer;
 begin
   Result := '';
   for i := 1 to Length(str) do

--- a/StreamTokenizer.pas
+++ b/StreamTokenizer.pas
@@ -14,11 +14,11 @@ type
     FReadBuf: PChar;
     FCurrent: PChar;
     FMark: PChar;
-    FPosition: integer;
-    FReadBufSize: integer;
-    function GetCurrent: char;
+    FPosition: Integer;
+    FReadBufSize: Integer;
+    function GetCurrent: Char;
     procedure Mark;
-    function Token: string;
+    function Token: String;
   public
     constructor Create(InputStream: TStream);
     destructor Destroy; override;
@@ -28,35 +28,35 @@ type
 
     { Returns the token that has been read so far and prepares the StreamTokenizer
     for reading the following token. }
-    function TokenAndMark: string;
+    function TokenAndMark: String;
 
     { Returns the next available character without advancing the current position }
-    function PeekNext: char;
+    function PeekNext: Char;
 
     { Returns a string that consists of the next characters without advancing
     the current position }
-    function PeekLength(Count: integer): string;
+    function PeekLength(Count: Integer): String;
 
     { Gets a value indicating whether all the characters have been read or not }
-    function IsEof: boolean;
+    function IsEof: Boolean;
 
     { Gets a value indicating whether the next character is an end of line }
-    function IsEoln: boolean;
+    function IsEoln: Boolean;
 
     { Gets a value indicating whether the current position is equal to the
     marked position }
-    function IsEmptyToken: boolean;
+    function IsEmptyToken: Boolean;
 
     { Advances the current position as long as the character is within the
     validChars set. The first character must be within the firstChar set.
     Returns true if the position was advanced, false otherwise. }
-    function Scan(firstChar, validChars: TSysCharSet): boolean;
+    function Scan(firstChar, validChars: TSysCharSet): Boolean;
 
     { Gets the character at the current position of the reader. }
-    property Current: char read GetCurrent;
+    property Current: Char read GetCurrent;
 
     { Gets the current position in the stream. }
-    property Position: integer read FPosition;
+    property Position: Integer read FPosition;
   end;
 
 implementation
@@ -78,7 +78,7 @@ begin
   FreeMem(FReadBuf);
 end;
 
-function TStreamTokenizer.GetCurrent: char;
+function TStreamTokenizer.GetCurrent: Char;
 begin
   GetCurrent := FCurrent^;
 end;
@@ -94,23 +94,23 @@ begin
   Inc(FPosition);
 end;
 
-function TStreamTokenizer.Token: string;
+function TStreamTokenizer.Token: String;
 var
-  tokenLen: integer;
-  tokenString: string;
+  tokenLen: Integer;
+  tokenString: String;
 begin
   tokenLen := FCurrent - FMark;
   SetString(tokenString, FMark, tokenLen);
   Token := tokenString;
 end;
 
-function TStreamTokenizer.TokenAndMark: string;
+function TStreamTokenizer.TokenAndMark: String;
 begin
   TokenAndMark := Token;
   Mark;
 end;
 
-function TStreamTokenizer.PeekNext: char;
+function TStreamTokenizer.PeekNext: Char;
 begin
   if IsEof then
     PeekNext := #0
@@ -118,22 +118,22 @@ begin
     PeekNext := (FCurrent + 1)^;
 end;
 
-function TStreamTokenizer.IsEof: boolean;
+function TStreamTokenizer.IsEof: Boolean;
 begin
   IsEof := Current = #0;
 end;
 
-function TStreamTokenizer.IsEmptyToken: boolean;
+function TStreamTokenizer.IsEmptyToken: Boolean;
 begin
   IsEmptyToken := FCurrent = FMark;
 end;
 
-function TStreamTokenizer.IsEoln: boolean;
+function TStreamTokenizer.IsEoln: Boolean;
 begin
   IsEoln := Current in [#13, #10];
 end;
 
-function TStreamTokenizer.Scan(firstChar: TSysCharSet; validChars: TSysCharSet): boolean;
+function TStreamTokenizer.Scan(firstChar: TSysCharSet; validChars: TSysCharSet): Boolean;
 begin
   if Current in firstChar then
   begin
@@ -147,10 +147,10 @@ begin
     Scan := False;
 end;
 
-function TStreamTokenizer.PeekLength(Count: integer): string;
+function TStreamTokenizer.PeekLength(Count: Integer): String;
 var
-  buffer: string;
-  i: integer;
+  buffer: String;
+  i: Integer;
 begin
   buffer := '';
   i := 0;

--- a/documenttypes.pas
+++ b/documenttypes.pas
@@ -26,12 +26,12 @@ implementation
 
 uses SysUtils;
 
-function IsCppFileExtension(const extension: string): boolean;
+function IsCppFileExtension(const extension: String): Boolean;
 begin
   IsCppFileExtension := (extension = '.cpp') or (extension = '.c') or (extension = '.h');
 end;
 
-function IsPascalFileExtension(const extension: string): boolean;
+function IsPascalFileExtension(const extension: String): Boolean;
 begin
   IsPascalFileExtension := (extension = '.pas') or (extension = '.dpr') or
     (extension = '.lpr');
@@ -39,7 +39,7 @@ end;
 
 function GetDocumentType(const FileName: String): TDocumentType;
 var
-  s: string;
+  s: String;
 begin
   s := ExtractFileExt(FileName);
   if IsCppFileExtension(s) then
@@ -53,4 +53,3 @@ begin
 end;
 
 end.
-

--- a/frmMain.pas
+++ b/frmMain.pas
@@ -40,14 +40,14 @@ type
     procedure SaveDialog1TypeChange(Sender: TObject);
   private
     FDocType: TDocumentType;
-    FCurFileName: string;
+    FCurFileName: String;
     procedure SetDocType(Value: TDocumentType);
-    procedure SetCurFileName(const Value: string);
-    procedure OpenFile(const FileName: string; aDocType: TDocumentType); overload;
+    procedure SetCurFileName(const Value: String);
+    procedure OpenFile(const FileName: String; aDocType: TDocumentType); overload;
     property DocType: TDocumentType read FDocType write SetDocType;
-    property CurFileName: string read FCurFileName write SetCurFileName;
+    property CurFileName: String read FCurFileName write SetCurFileName;
   public
-    procedure OpenFile(const FileName: string); overload;
+    procedure OpenFile(const FileName: String); overload;
   end;
 
 var
@@ -59,7 +59,7 @@ uses frmAbout;
 
 {$R *.lfm}
 
-procedure TMainForm.SetCurFileName(const Value: string);
+procedure TMainForm.SetCurFileName(const Value: String);
 begin
   FCurFileName := Value;
   Statusbar1.SimpleText := Value;
@@ -72,7 +72,7 @@ begin
   FileSaveAs.Enabled := FDocType <> dtNone;
 end;
 
-procedure TMainForm.OpenFile(const FileName: string; aDocType: TDocumentType);
+procedure TMainForm.OpenFile(const FileName: String; aDocType: TDocumentType);
 var
   InputStream: TFileStream;
   OutputStream: TMemoryStream;
@@ -117,13 +117,14 @@ begin
   AboutForm.ShowModal;
 end;
 
-procedure TMainForm.OpenFile(const FileName: string);
+procedure TMainForm.OpenFile(const FileName: String);
 var
   DocumentType: TDocumentType;
 begin
   DocumentType := GetDocumentType(FileName);
   if DocumentType = dtNone then
-    MessageDlg('Αυτή η μορφή δεν υποστηρίζεται', mtError, [mbOK], 0)
+    MessageDlg('Αυτή η μορφή δεν υποστηρίζεται',
+      mtError, [mbOK], 0)
   else
     OpenFile(FileName, DocumentType);
 end;


### PR DESCRIPTION
The following fixes have been applied:
- chore: Auto-formatted Pascal files: CodeFmt.lpr, CppLexer.pas, documenttypes.pas, FormatterBase.pas, frmMain.pas, HTMLFormatter.pas, LexerBase.pas, PascalLexer.pas, RTFFormatter.pas, StreamTokenizer.pas
